### PR TITLE
Add RET (Real Estate Token) to Ethereum token list

### DIFF
--- a/src/tokens/eth.json
+++ b/src/tokens/eth.json
@@ -1,0 +1,10 @@
+[
+  {
+    "chainId": 1,
+    "address": "0x779599e50318c717B40a9688f54746f8cAf6659b",
+    "name": "Real Estate Token",
+    "symbol": "RET",
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/PMScash/token-lists/master/assets/ret.png"
+  }
+]


### PR DESCRIPTION
Adds RET (Real Estate Token) to SushiSwap's default Ethereum token list.

- Contract: `0x779599e50318c717B40a9688f54746f8cAf6659b`
- Symbol: `RET`
- Decimals: `18`
- Logo: `assets/ret.png`

Logo hosted in: `https://raw.githubusercontent.com/PMSCash/token-lists/master/assets/ret.png`
